### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/wlonk/dark_api.png?label=ready&title=Ready)](https://waffle.io/wlonk/dark_api)
 # Dark API
 
 [![Circle CI](https://circleci.com/gh/wlonk/dark_api.svg?style=svg)](https://circleci.com/gh/wlonk/dark_api)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/wlonk/dark_api

This was requested by a real person (user wlonk) on waffle.io, we're not trying to spam you.
